### PR TITLE
backend: implement update() for fields and attributes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,6 +217,32 @@ class TestAPIAttributes(unittest.TestCase):
         ev, = get_events()
         self.assertEqual(ev.a_int, 12)
 
+    def test_create_and_update_string_list_field_and_attribute_of_event(self):
+        e = Event(dt.datetime.now(), dt.datetime.now() + dt.timedelta(days=1),
+                  "Patrick",
+                  products=["mms2"],
+                  str_list=["hello", "world"])
+        save()
+
+        self.assertListEqual(get_events(), [e])
+        e.products = ["mms1"]
+        e.str_list = ["goodbye", "earth"]
+
+        self.assertListEqual(get_events(), [e])
+
+    def test_create_and_update_string_list_field_and_attribute_of_catalogue(self):
+        c = Catalogue("Catalogue Name",
+                      "Patrick",
+                      tags=["mms2"],
+                      str_list=["hello", "world"])
+        save()
+
+        self.assertListEqual(get_catalogues(), [c])
+        c.tags = ["mms1"]
+        c.str_list = ["goodbye", "earth"]
+
+        self.assertListEqual(get_catalogues(), [c])
+
 
 @ddt
 class TestAPIField(unittest.TestCase):

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -186,6 +186,8 @@ class TestDynamicCatalogue(unittest.TestCase):
             Event(dt.datetime.now(), dt.datetime.now() + dt.timedelta(days=2), "Patrick"),
             Event(dt.datetime.now(), dt.datetime.now() + dt.timedelta(days=3), "Patrick"),
             Event(dt.datetime.now(), dt.datetime.now() + dt.timedelta(days=3), "Alexis"),
+            Event(dt.datetime.now(), dt.datetime.now() + dt.timedelta(days=3), "Alexis"),
+            Event(dt.datetime.now(), dt.datetime.now() + dt.timedelta(days=3), "Alexis"),
         ]
 
         self.catalogue = Catalogue("Catalogue A", "Patrick", events=self.events)
@@ -221,3 +223,13 @@ class TestDynamicCatalogue(unittest.TestCase):
         self.assertFalse(catalogues[0].is_dynamic())
         self.assertTrue(catalogues[1].is_dynamic())
         self.assertEqual(catalogues[1], dcat)
+
+    def test_predicate_field_is_updatable(self):
+        dc = Catalogue("Dynamic Catalogue", "Patrick",
+                       predicate=Comparison("==", Field("author"), "Patrick"))
+
+        self.assertListEqual(get_events(dc), self.events[:3])
+
+        dc.predicate = Comparison("==", Field("author"), "Alexis")
+
+        self.assertListEqual(get_events(dc), self.events[3:])

--- a/tscat/__init__.py
+++ b/tscat/__init__.py
@@ -80,11 +80,10 @@ class _BackendBasedEntity:
         super(_BackendBasedEntity, self).__setattr__(key, value)
 
         if key != '_in_ctor' and not self._in_ctor:
-            # TODO use backend().add
             if key in self._fixed_keys:
-                setattr(self._backend_entity, key, value)
+                backend().update_field(self._backend_entity, key, value)
             elif _valid_key.match(key):
-                self._backend_entity[key] = value
+                backend().update_attribute(self._backend_entity, key, value)
 
     def __delattr__(self, key):
         super(_BackendBasedEntity, self).__delattr__(key)
@@ -93,8 +92,7 @@ class _BackendBasedEntity:
         if key in self._fixed_keys:
             raise IndexError('Fixed keys cannot be deleted.')
         if _valid_key.match(key):
-            # backend().del
-            del self._backend_entity[key]
+            backend().delete_attribute(self._backend_entity, key)
 
     def __eq__(self, o):
         if sorted(filter(_valid_key.match, self.__dict__.keys())) != \
@@ -147,7 +145,7 @@ class Event(_BackendBasedEntity):
         self.__dict__.update(kwargs)
 
         if _insert:
-            self._backend_entity = backend().add_or_update_event({
+            self._backend_entity = backend().add_event({
                 'start': self.start,
                 'stop': self.stop,
                 'author': self.author,
@@ -208,7 +206,7 @@ class Catalogue(_BackendBasedEntity):
         self.__dict__.update(kwargs)
 
         if _insert:
-            self._backend_entity = backend().add_or_update_catalogue({
+            self._backend_entity = backend().add_catalogue({
                 'name': self.name,
                 'author': self.author,
                 'uuid': self.uuid,

--- a/tscat/orm_sqlalchemy/orm.py
+++ b/tscat/orm_sqlalchemy/orm.py
@@ -43,7 +43,7 @@ class ProxiedDictMixin(object):
     def __delitem__(self, key):
         del self._proxied[key]
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return json.dumps({k: v for k, v in self.proxied.items() if not k.startswith('_')}, indent=1)
 
 
@@ -128,7 +128,7 @@ class PolymorphicVerticalProperty(object):
             else:
                 return literal_column(fieldname).contains(other, **kwargs)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f"<{self.__class__.__name__} {self.key}={self.value}>"
 
 
@@ -251,7 +251,7 @@ class Event(ProxiedDictMixin, Base):
         self.tags = tags
         self.products = products
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f'Event({self.id}: {self.start}, {self.stop}, {self.author}), {self.removed}, meta=' + self._proxied.__repr__()
 
 
@@ -318,5 +318,5 @@ class Catalogue(ProxiedDictMixin, Base):
         self.tags = tags
         self.predicate = predicate
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f'Catalogue({self.id}: {self.name}, {self.author}, {self.removed}), attrs=' + self._proxied.__repr__()


### PR DESCRIPTION
This correctly implements a clean barrier between the back-end and the front-end in terms of updating fields and attributes.

It also fixes updates of special fields: tags, products and predicate; which weren't working before (and were untested!)

Fixes #8