### PR TITLE
get_events: option to only assigned get_events of a (dynamic) catalogue

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -153,6 +153,16 @@ class TestEventFiltering(unittest.TestCase):
         event_list = get_events(All(pred))
         self.assertListEqual(event_list, [events[i] for i in idx])
 
+    def test_get_only_manually_added_events_from_dynamic_catalogue(self):
+        cat = create_catalogue('T', 'A')
+        cat.predicate = Comparison("==", Field('author'), 'Patrick')
+
+        assert get_events(cat) == [events[0]]
+
+        add_events_to_catalogue(cat, events[1])
+        assert get_events(cat) == [events[0], events[1]]
+
+        assert get_events(cat, assigned_only=True) == [events[1]]
 
 @ddt
 class TestStringListAttributes(unittest.TestCase):

--- a/tscat/__init__.py
+++ b/tscat/__init__.py
@@ -311,13 +311,16 @@ def get_catalogues(base: Union[Predicate, _Event, None] = None, removed_items: b
     return catalogues
 
 
-def get_events(base: Union[Predicate, _Catalogue, None] = None, removed_items: bool = False) -> List[_Event]:
+def get_events(base: Union[Predicate, _Catalogue, None] = None,
+               removed_items: bool = False,
+               assigned_only: bool = False) -> List[_Event]:
     base_dict: Dict[str, Union[Predicate, 'Catalogue', None, bool]]
     if isinstance(base, Predicate):
         base_dict = {'predicate': base}
     elif isinstance(base, _Catalogue):
-        base_dict = {'entity': base._backend_entity,
-                     'predicate': base.predicate}
+        base_dict = {'entity': base._backend_entity}
+        if not assigned_only:
+            base_dict['predicate'] = base.predicate
     else:
         base_dict = {}
 


### PR DESCRIPTION
Feature needed for tscat_gui to correctly undelete permanently deleted dynamic catalogues.