### PR TITLE
is_removed is now cached

### DIFF
--- a/tscat/orm_sqlalchemy/__init__.py
+++ b/tscat/orm_sqlalchemy/__init__.py
@@ -292,7 +292,3 @@ class Backend:
     @staticmethod
     def restore(entity: Union[orm.Catalogue, orm.Event]) -> None:
         entity.removed = False
-
-    @staticmethod
-    def is_removed(entity: Union[orm.Catalogue, orm.Event]) -> bool:
-        return entity.removed


### PR DESCRIPTION
The removed-state of an entity was always fetched from the backend. This causes troubles in multi-threaded environments. Not is_removed is a cache-field of an entity.