### PR TITLE
Fix import failure on large catalogues (SQLite variable limit)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -507,6 +507,18 @@ class TestImportExportJSON(unittest.TestCase):
         assert get_events() == events
         assert get_events(c)[0] == [events[1]]
 
+    def test_import_catalogue_with_more_events_than_sqlite_variable_limit(self):
+        events = [generate_event() for _ in range(1100)]
+        catalogue = create_catalogue('BigCatalogue', 'Patrick', events=events)
+
+        export_blob = export_json(catalogue)
+        discard()
+        imported = import_json(export_blob)
+        self.assertEqual(len(imported), 1)
+        imported_events = get_events(imported[0])
+        assert isinstance(imported_events, tuple)
+        self.assertEqual(len(imported_events[0]), 1100)
+
 
 class TestTrash(unittest.TestCase):
     def setUp(self) -> None:

--- a/tscat/orm_sqlalchemy/__init__.py
+++ b/tscat/orm_sqlalchemy/__init__.py
@@ -314,8 +314,14 @@ class Backend:
 
     def get_events_by_uuid_list(self, uuids: List[str]) -> Dict[str, orm.Event]:
         self.session.flush()
-        stmt = select(orm.Event).filter(orm.Event.uuid.in_(uuids))
-        return {e.uuid: e for e in self.session.scalars(stmt).all()}
+        # SQLite limits bind parameters per query (~999), so chunk the list
+        result: Dict[str, orm.Event] = {}
+        chunk_size = 900
+        for i in range(0, len(uuids), chunk_size):
+            chunk = uuids[i:i + chunk_size]
+            stmt = select(orm.Event).filter(orm.Event.uuid.in_(chunk))
+            result.update({e.uuid: e for e in self.session.scalars(stmt).all()})
+        return result
 
     def get_existing_tags(self) -> Set[str]:
         self.session.flush()


### PR DESCRIPTION
## Summary
- `get_events_by_uuid_list` passed all UUIDs in a single `WHERE IN (?, ?, ...)` clause, exceeding SQLite's ~999 bind parameter limit when importing catalogues with >999 events
- Fixed by chunking the UUID list into batches of 900
- Added regression test importing a catalogue with 1100 events

## Test plan
- [x] New test `test_import_catalogue_with_more_events_than_sqlite_variable_limit` passes
- [x] All 80 existing tests pass
- [x] Successfully imported GRMB.json (70k events, 7 catalogues) manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)